### PR TITLE
refactor the sync string and make leaflet hash more robust

### DIFF
--- a/R/latticeView.R
+++ b/R/latticeView.R
@@ -69,21 +69,18 @@ latticeView <- function(...,
   ls <- list(...)
   if (length(ls) == 1) ls <- ls[[1]]
 
-  ## include dependency Leaflet.Sync in all maps
-  sync_dep <- htmltools::htmlDependency(
-    name = "Leaflet.Sync"
-    ,version = "0.0.5"
-    ,src = c(file = system.file("htmlwidgets/lib/Leaflet.Sync",
-                                package = "mapview"))
-    ,script = "L.Map.Sync.js"
-  )
-
   for (i in seq(ls)) {
     if (inherits(ls[[i]], "mapview")) ls[[i]] <- mapview2leaflet(ls[[i]])
     if(length(ls[[i]]$dependencies) == 0){
       ls[[i]]$dependencies = list()
     }
     #ls[[i]]$dependencies[[length(ls[[i]]$dependencies) + 1]] <- sync_dep
+    # give a "unique" id to each leaflet map for lookup
+    if(is.null(ls[[i]]$elementId)){
+      # use unique same id generator as htmlwidgets
+      #  https://github.com/ramnathv/htmlwidgets/blob/master/R/htmlwidgets.R#L165
+      ls[[i]]$elementId <- paste("htmlwidget", as.integer(stats::runif(1, 1, 10000)), sep="-")
+    }
   }
 
   ## calculate div width depending on ncol and set div style
@@ -98,51 +95,53 @@ latticeView <- function(...,
   })
 
   ## string operations for syncing, depending on sync argument
+  ## initialize sync_string as empty
+  sync_strng <- ""
+  if(!is.list(sync) && sync=="all"){
+    sync = list(seq(ls))
+  }
   if (is.list(sync)) {
-    sync_strng <- Reduce(paste0, sapply(seq(sync), function(i) {
-      first <-  do.call(c, lapply(seq(sync[[i]]), function(j) {
-        rep(paste0("leaf_widgets[", sync[[i]][[j]] - 1, "]"), length(sync[[i]]) - 1)
-      }))
-      second <- rev(do.call(c, lapply(seq(sync[[i]]), function(j) {
-        paste0(".sync(leaf_widgets[", sync[[i]][[j]] - 1,
-               "], {syncCursor: ",
-               tolower(sync.cursor),
-               ", noInitialSync: ",
-               tolower(no.initial.sync),
-               "});")
-      })))
-      paste0(first, second)
-    }))
-  } else if (sync == "all") {
-    sync_strng <- Reduce(paste0, sapply(seq(ls), function(i) {
-      first <-  do.call(c, lapply(seq(ls), function(j) {
-        paste0("leaf_widgets[", j - 1, "]")
-      }))[-i]
-      second <- paste0(".sync(leaf_widgets[", i - 1,
-                       "], {syncCursor: ",
-                       tolower(sync.cursor),
-                       ", noInitialSync: ",
-                       tolower(no.initial.sync),
-                       "});")
-      paste0(first, second)
-    }))
-  } else sync_strng <- ""
+    for (i in seq(sync)) {
+      synci <- sync[[i]]
+      sync_grid <- expand.grid(synci,synci,KEEP.OUT.ATTRS=FALSE)
+      sync_strng <- c(sync_strng,apply(
+        sync_grid,
+        MARGIN=1,
+        function(combo){
+          # don't sync to self
+          if(combo[1] != combo[2]){
+            return(sprintf(
+              "leaf_widgets['%s'].sync(leaf_widgets['%s'],{syncCursor: %s, noInitialSync: %s});",
+              ls[[combo[1]]]$elementId,
+              ls[[combo[2]]]$elementId,
+              tolower(as.logical(sync.cursor)),
+              tolower(as.logical(no.initial.sync))
+            ))
+          }
+          return("")
+        }
+      ))
+    }
+  }
+  sync_strng <- paste0(sync_strng,collapse="\n")
 
   tl <- htmltools::attachDependencies(
     htmltools::tagList(
       tg,
       htmlwidgets::onStaticRenderComplete(
-        paste0('var leaf_widgets = Array.prototype.map.call(
+        paste0('var leaf_widgets = {};
+                Array.prototype.map.call(
                  document.querySelectorAll(".leaflet"),
                    function(ldiv){
-                     return HTMLWidgets.find("#" + ldiv.id);
+                     leaf_widgets[ldiv.id] = HTMLWidgets.find("#" + ldiv.id);
                    }
-               );',
+                );
+               ',
                sync_strng
         )
       )
     ),
-    sync_dep
+    dependencyLeafletsync()
   )
 
   return(htmltools::browsable(tl))
@@ -186,3 +185,18 @@ latticeview <- function(...) latticeView(...)
 #   type="text/javascript",
 #   src="https://cdn.rawgit.com/turban/Leaflet.Sync/master/L.Map.Sync.js"
 # )),
+
+
+#' Provide Leaflet.sync Dependency
+#'
+#' @return \code{\link[htmltools]{htmlDependency}}
+#' @export
+dependencyLeafletsync <- function(){
+  htmltools::htmlDependency(
+    name = "Leaflet.Sync"
+    ,version = "0.0.5"
+    ,src = c(file = system.file("htmlwidgets/lib/Leaflet.Sync",
+                                package = "mapview"))
+    ,script = "L.Map.Sync.js"
+  )
+}


### PR DESCRIPTION
ref #19 

This pull does four things:

- add `elementId` to the leaflet htmlwidgets, so that we can refer to them in `latticeView` for sync
- change the sync `JS` code to use our new leaflet hash
- refactor the `R` generation of the sync `JS` code to consolidate into one method for easier maintenance
- abstract out the `Leaflet.sync` dependency to `dependencyLeafletsync()` in case we want to use it elsewhere

I tested with all the code provided in the examples.  @tim-salabim, please test on your end also.