### PR TITLE
Convert popup to UTF-8

### DIFF
--- a/src/brewCppFun.cpp
+++ b/src/brewCppFun.cpp
@@ -154,6 +154,22 @@ std::string createTemplate(std::string tmpPath) {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+// Convert String to UTF-8 //////////////// ////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+
+String enc2utf8_string(const String & x) {
+  String str(x);
+  str.set_encoding(CE_UTF8);
+  return str;
+}
+
+CharacterVector enc2utf8_chrvec(const CharacterVector & x) {
+  CharacterVector str(x.size());
+  std::transform(x.begin(), x.end(), str.begin(), enc2utf8_string);
+  return str;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 // Create list with string patterns per row ////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -174,15 +190,14 @@ List listPopupTemplates(CharacterMatrix x, CharacterVector names,
 
   // import template
   std::string chTemplate = createTemplate(tmpPath);
-  std::string chTmp = chTemplate;
+  String chTmp = chTemplate;
 
   // create strings for each single row
   for (int i = 0; i < nRows; i++) {
-    chVal = x(i, _);
+    chVal = enc2utf8_chrvec(x(i, _));
     chStr = mergePopupRows(names, chVal);
 
-    chTmp = gsubC("<%=pop%>", chStr, chTmp);
-    lsOut[i] = chTmp;
+    lsOut[i] = enc2utf8_string(gsubC("<%=pop%>", chStr, chTmp));;
 
     // reset intermediary string
     chTmp = chTemplate;


### PR DESCRIPTION
This PR fixes #65.

In non-UTF-8 environment, strings behave very tricky. I've performed a simple test to handle encodings in Rcpp:

``` r
cppfile <- tempfile(fileext = ".cpp")
cat("
#include <Rcpp.h>
using namespace Rcpp;

// [[Rcpp::export]]
std::string std2std(const std::string &x) {
  return x;
}

// [[Rcpp::export]]
std::string str2std(const String &x) {
  std::string y(x);
  return y;
}

// [[Rcpp::export]]
std::string str2std_utf8(const String &x) {
  String y(x);
  y.set_encoding(CE_UTF8);
  return y;
}

// [[Rcpp::export]]
String str2str(const String &x) {
  std::string y(x);
  return y;
}

// [[Rcpp::export]]
String str2str_utf8(const String &x) {
  String y(x);
  y.set_encoding(CE_UTF8);
  return y;
}
", file = cppfile)
Rcpp::sourceCpp(cppfile)
purrr::invoke_map_chr(list(std2std, str2std, str2std_utf8, str2str, str2str_utf8),
                      "ニンジャスレイヤー")
#> [1] "ニンジャスレイヤー"                                                                 
#> [2] "ニンジャスレイヤー"                                                                 
#> [3] "繝九Φ繧ｸ繝｣繧ｹ繝ｬ繧､繝､繝ｼ"                                                        
#> [4] "<U+0083>j<U+0083><U+0093><U+0083>W<U+0083><U+0083><U+0083>X<U+0083><U+008C><U+0083>C<U+0083><U+0084><U+0081>["
#> [5] "ニンジャスレイヤー"
purrr::invoke_map_chr(list(std2std, str2std, str2std_utf8, str2str, str2str_utf8),
                      enc2utf8("ニンジャスレイヤー"))
#> [1] "繝九Φ繧ｸ繝｣繧ｹ繝ｬ繧､繝､繝ｼ" "繝九Φ繧ｸ繝｣繧ｹ繝ｬ繧､繝､繝ｼ"
#> [3] "繝九Φ繧ｸ繝｣繧ｹ繝ｬ繧､繝､繝ｼ" "ニンジャスレイヤー"         
#> [5] "ニンジャスレイヤー"
```

<details><summary>Session info</summary>

``` r
devtools::session_info()
#> Session info -------------------------------------------------------------
#>  setting  value                       
#>  version  R version 3.3.3 (2017-03-06)
#>  system   x86_64, mingw32             
#>  ui       RTerm                       
#>  language (EN)                        
#>  collate  Japanese_Japan.932          
#>  tz       Asia/Tokyo                  
#>  date     2017-03-24
#> Packages -----------------------------------------------------------------
#>  package   * version     date       source                          
#>  backports   1.0.5       2017-01-18 CRAN (R 3.3.2)                  
#>  devtools    1.12.0.9000 2016-11-30 Github (hadley/devtools@e6df6cf)
#>  digest      0.6.12      2017-01-27 CRAN (R 3.3.2)                  
#>  evaluate    0.10        2016-10-11 CRAN (R 3.3.1)                  
#>  htmltools   0.3.5       2016-03-21 CRAN (R 3.3.1)                  
#>  knitr       1.15.1      2016-11-22 CRAN (R 3.3.2)                  
#>  lazyeval    0.2.0       2016-06-12 CRAN (R 3.3.1)                  
#>  magrittr    1.5         2014-11-22 CRAN (R 3.3.1)                  
#>  memoise     1.0.0       2016-01-29 CRAN (R 3.3.1)                  
#>  pkgbuild    0.0.0.9000  2017-03-19 Github (r-pkgs/pkgbuild@5ed87aa)
#>  pkgload     0.0.0.9000  2017-03-19 Github (r-pkgs/pkgload@3a96cf2) 
#>  purrr       0.2.2       2016-06-18 CRAN (R 3.3.1)                  
#>  Rcpp        0.12.10     2017-03-19 CRAN (R 3.3.3)                  
#>  rmarkdown   1.3         2016-12-21 CRAN (R 3.3.2)                  
#>  rprojroot   1.2         2017-01-16 CRAN (R 3.3.2)                  
#>  stringi     1.1.2       2016-10-01 CRAN (R 3.3.1)                  
#>  stringr     1.2.0       2017-02-18 CRAN (R 3.3.2)                  
#>  withr       1.0.2       2016-06-20 CRAN (R 3.3.1)                  
#>  yaml        2.1.14      2016-11-12 CRAN (R 3.3.2)
```

</details>


As you can see, only the last one works fine. This result indicates that we have to convert both input and output to UTF-8 `String`. Otherwise, the encoding information will be lost somehow. Note that you may not see this problem in UTF-8 environment (e.g. Mac, Linux and English Windows), but those who are in non-UTF-8 environment like I will suffer the issue.